### PR TITLE
improve unit test performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
                 "@tailwindcss/typography": "^0.5.14",
                 "@testcontainers/postgresql": "^10.13.1",
                 "@types/eslint": "^9.6.0",
+                "async-mutex": "^0.5.0",
                 "autoprefixer": "^10.4.20",
                 "drizzle-kit": "^0.24.2",
                 "eslint": "^9.0.0",
@@ -3073,6 +3074,16 @@
             "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/async-mutex": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+            "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
         },
         "node_modules/autoprefixer": {
             "version": "10.4.20",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@tailwindcss/typography": "^0.5.14",
         "@testcontainers/postgresql": "^10.13.1",
         "@types/eslint": "^9.6.0",
+        "async-mutex": "^0.5.0",
         "autoprefixer": "^10.4.20",
         "drizzle-kit": "^0.24.2",
         "eslint": "^9.0.0",

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,27 +1,3 @@
-import { channelBannedUserTable } from './bans.channels.users.sql';
-import { userBlockTable } from './blocks.users.sql';
-import { channelTable } from './channels.sql';
-import { commentTable } from './comments.sql';
-import { followTable } from './follows.sql';
-import { inviteTable } from './invites.sql';
-import { playlistPostTable } from './playlists.posts.sql';
-import { playlistTable } from './playlists.sql';
-import { postTable } from './posts.sql';
-import { publicChannelTable } from './public.channels.sql';
-import { channelPostReportTable } from './reports.channels.posts.sql';
-import { channelReportTable } from './reports.channels.sql';
-import { channelUserReportTable } from './reports.channels.users.sql';
-import { userReportTable } from './reports.users.sql';
-import { roleTable } from './roles.sql';
-import { userRoleTable } from './roles.users.sql';
-import { sessionTable } from './sessions.sql';
-import { subscriptionTable } from './subscriptions.sql';
-import { channelTagsTable } from './tags.channels.sql';
-import { postTagTable } from './tags.posts.sql';
-import { userTable } from './users.sql';
-import { commentVoteTable } from './votes.comments.sql';
-import { postVoteTable } from './votes.posts.sql';
-
 export * from './bans.channels.users.sql';
 export * from './blocks.users.sql';
 export * from './channels.sql';
@@ -46,36 +22,6 @@ export * from './tags.posts.sql';
 export * from './users.sql';
 export * from './votes.comments.sql';
 export * from './votes.posts.sql';
-
-/**
- * This is a list of all of our database tables
- * It is essential that this list be kept up to date to guarantee test isolation
- */
-export const tables = [
-    channelBannedUserTable,
-    userBlockTable,
-    subscriptionTable,
-    commentTable,
-    followTable,
-    inviteTable,
-    playlistPostTable,
-    playlistTable,
-    publicChannelTable,
-    channelPostReportTable,
-    channelReportTable,
-    channelUserReportTable,
-    userReportTable,
-    roleTable,
-    userRoleTable,
-    sessionTable,
-    channelTagsTable,
-    postTagTable,
-    commentVoteTable,
-    postVoteTable,
-    postTable,
-    channelTable,
-    userTable,
-];
 
 /**
 To simplify the definition of the Drizzle config, it's best if the schema is all contained a single module. Thus,

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,3 +1,27 @@
+import { channelBannedUserTable } from './bans.channels.users.sql';
+import { userBlockTable } from './blocks.users.sql';
+import { channelTable } from './channels.sql';
+import { commentTable } from './comments.sql';
+import { followTable } from './follows.sql';
+import { inviteTable } from './invites.sql';
+import { playlistPostTable } from './playlists.posts.sql';
+import { playlistTable } from './playlists.sql';
+import { postTable } from './posts.sql';
+import { publicChannelTable } from './public.channels.sql';
+import { channelPostReportTable } from './reports.channels.posts.sql';
+import { channelReportTable } from './reports.channels.sql';
+import { channelUserReportTable } from './reports.channels.users.sql';
+import { userReportTable } from './reports.users.sql';
+import { roleTable } from './roles.sql';
+import { userRoleTable } from './roles.users.sql';
+import { sessionTable } from './sessions.sql';
+import { subscriptionTable } from './subscriptions.sql';
+import { channelTagsTable } from './tags.channels.sql';
+import { postTagTable } from './tags.posts.sql';
+import { userTable } from './users.sql';
+import { commentVoteTable } from './votes.comments.sql';
+import { postVoteTable } from './votes.posts.sql';
+
 export * from './bans.channels.users.sql';
 export * from './blocks.users.sql';
 export * from './channels.sql';
@@ -22,6 +46,36 @@ export * from './tags.posts.sql';
 export * from './users.sql';
 export * from './votes.comments.sql';
 export * from './votes.posts.sql';
+
+/**
+ * This is a list of all of our database tables
+ * It is essential that this list be kept up to date to guarantee test isolation
+ */
+export const tables = [
+    channelBannedUserTable,
+    userBlockTable,
+    subscriptionTable,
+    commentTable,
+    followTable,
+    inviteTable,
+    playlistPostTable,
+    playlistTable,
+    publicChannelTable,
+    channelPostReportTable,
+    channelReportTable,
+    channelUserReportTable,
+    userReportTable,
+    roleTable,
+    userRoleTable,
+    sessionTable,
+    channelTagsTable,
+    postTagTable,
+    commentVoteTable,
+    postVoteTable,
+    postTable,
+    channelTable,
+    userTable,
+];
 
 /**
 To simplify the definition of the Drizzle config, it's best if the schema is all contained a single module. Thus,

--- a/src/lib/server/services/channels.spec.ts
+++ b/src/lib/server/services/channels.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test } from 'vitest';
+import { describe } from 'vitest';
 import {
     getChannelById,
     getChannelInfo,
@@ -8,7 +8,7 @@ import {
     createChannel,
     publishChannel,
 } from './channels';
-import { mustGenerate, withDb } from '$lib/testing/utils';
+import { mustGenerate, testWithDb } from '$lib/testing/utils';
 import { channelTable } from '../db/channels.sql';
 import { userTable } from '../db/users.sql';
 import type { DB } from '..';
@@ -54,36 +54,43 @@ const generateUser = async (db: DB) => {
 };
 
 describe.concurrent('channels suite', () => {
-    test('getting channels returns successfully', async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        'getting channels returns successfully',
+        async ({ expect, db, generated }) => {
             const { createdChannel } = mustGenerate(generated);
 
             const channels = await getChannels(db);
             expect(channels.length).toStrictEqual(1);
             expect(channels[0].name).toStrictEqual(createdChannel.name);
-        }, generateUserAndChannel);
-    });
+        },
+        generateUserAndChannel
+    );
 
-    test('getting channel by id returns successfully', async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        'getting channel by id returns successfully',
+        async ({ expect, db, generated }) => {
             const { createdChannel } = mustGenerate(generated);
 
             const channel = await getChannelById(db, createdChannel.id);
             expect(channel?.name).toStrictEqual(createdChannel.name);
-        }, generateUserAndChannel);
-    });
+        },
+        generateUserAndChannel
+    );
 
-    test('getting channels by user id returns successfully', async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        'getting channels by user id returns successfully',
+        async ({ expect, db, generated }) => {
             const { creator, createdChannel } = mustGenerate(generated);
 
             const userChannels = await getChannelsByOwner(db, creator.id);
             expect(userChannels).toStrictEqual([createdChannel]);
-        }, generateUserAndChannel);
-    });
+        },
+        generateUserAndChannel
+    );
 
-    test("user's subscriptions can be fetched", async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        "user's subscriptions can be fetched",
+        async ({ expect, db, generated }) => {
             const {
                 createdChannel,
                 subscribers: [subscriber],
@@ -92,37 +99,45 @@ describe.concurrent('channels suite', () => {
             expect(subscribedChannels).toStrictEqual([
                 { channelId: createdChannel.id, channelDisplayName: createdChannel.name },
             ]);
-        }, generateChannelAndSubs);
-    });
+        },
+        generateChannelAndSubs
+    );
 
-    test("user's subscriptions can be fetched when there aren't any", async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        "user's subscriptions can be fetched when there aren't any",
+        async ({ expect, db, generated }) => {
             const { creator } = mustGenerate(generated);
             const subscribedChannels = await getUserSubscriptions(db, creator.id);
             expect(subscribedChannels).toStrictEqual([]);
-        }, generateUserAndPublicChannel);
-    });
+        },
+        generateUserAndPublicChannel
+    );
 
-    test('many subscriptions are counted correctly', async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        'many subscriptions are counted correctly',
+        async ({ expect, db, generated }) => {
             const { createdChannel, subscriptionCount } = mustGenerate(generated);
 
             const channelInfo = await getChannelInfo(db, createdChannel.id);
             expect(channelInfo.subscriptionsCount).toStrictEqual(subscriptionCount);
-        }, generateChannelAndSubs);
-    });
+        },
+        generateChannelAndSubs
+    );
 
-    test('zero subscriptions are counted correctly', async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        'zero subscriptions are counted correctly',
+        async ({ expect, db, generated }) => {
             const { createdChannel } = mustGenerate(generated);
 
             const channelInfo = await getChannelInfo(db, createdChannel.id);
             expect(channelInfo.subscriptionsCount).toStrictEqual(0);
-        }, generateUserAndPublicChannel);
-    });
+        },
+        generateUserAndPublicChannel
+    );
 
-    test('creating channels returns successfully', async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        'creating channels returns successfully',
+        async ({ expect, db, generated }) => {
             const { creator } = mustGenerate(generated);
 
             const userChannels = await createChannel(db, {
@@ -132,16 +147,19 @@ describe.concurrent('channels suite', () => {
                 guidelines: 'None',
             });
             expect(userChannels.name).toStrictEqual("Evan's Channel");
-        }, generateUser);
-    });
+        },
+        generateUser
+    );
 
-    test('publishing channels returns successfully', async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        'publishing channels returns successfully',
+        async ({ expect, db, generated }) => {
             const { createdChannel } = mustGenerate(generated);
 
             const publishedChannel: PublicChannel = await publishChannel(db, createdChannel);
 
             expect(publishedChannel.name).toStrictEqual(createdChannel.name);
-        }, generateUserAndChannel);
-    });
+        },
+        generateUserAndChannel
+    );
 });

--- a/src/lib/server/services/content.spec.ts
+++ b/src/lib/server/services/content.spec.ts
@@ -1,5 +1,5 @@
-import { describe, test } from 'vitest';
-import { mustGenerate, withDb } from '$lib/testing/utils';
+import { describe } from 'vitest';
+import { mustGenerate, testWithDb } from '$lib/testing/utils';
 import type { DB } from '..';
 import { userTable } from '../db/users.sql';
 import { channelTable } from '../db/channels.sql';
@@ -92,8 +92,9 @@ const generateStatContext = async (db: DB) => {
 };
 
 describe.concurrent('content suite', () => {
-    test('post list contains correct data', async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        'post list contains correct data',
+        async ({ expect, db, generated }) => {
             const gen = mustGenerate(generated);
 
             const [a, b, ...rest] = await getPosts(db, 0, {
@@ -127,11 +128,13 @@ describe.concurrent('content suite', () => {
             expect(p2.poster.user.name).toStrictEqual(gen.creator.username);
             expect(p2.poster.channel.id).toStrictEqual(gen.channel.id);
             expect(p2.poster.channel.name).toStrictEqual(gen.channel.name);
-        }, generateStatContext);
-    });
+        },
+        generateStatContext
+    );
 
-    test('site statistics is calculated correctly', async ({ expect }) => {
-        await withDb(async ({ db, generated }) => {
+    testWithDb(
+        'site statistics is calculated correctly',
+        async ({ expect, db, generated }) => {
             const { votes } = mustGenerate(generated);
 
             const { numberOfChannelsWithPosts, numberOfPosts, numberOfUpvotes, numberOfDownvotes } =
@@ -143,6 +146,7 @@ describe.concurrent('content suite', () => {
             expect(numberOfDownvotes).toStrictEqual(
                 votes.downvotes1.length + votes.downvotes2.length
             );
-        }, generateStatContext);
-    });
+        },
+        generateStatContext
+    );
 });

--- a/src/lib/server/services/content.ts
+++ b/src/lib/server/services/content.ts
@@ -210,8 +210,6 @@ export const getPosts = async (db: DB, page: number, filter: PostFilter): Promis
         .limit(PAGE_SIZE)
         .offset(page * PAGE_SIZE);
 
-    console.log(q.toSQL());
-
     return (await q).map((p) => ({
         id: p.id,
         title: p.title,

--- a/src/lib/testing/utils.ts
+++ b/src/lib/testing/utils.ts
@@ -16,6 +16,11 @@ const startedContainer = await container.start();
 const db = await createDb(startedContainer.getConnectionUri());
 const lock = new Mutex();
 
+const tableNames: string[] = [];
+for (const tableName in db._.tableNamesMap) {
+    if (tableName != '') tableNames.push(tableName);
+}
+
 export const mustGenerate = <T>(generated: T | null) => {
     if (!generated) process.exit(1);
     return generated;
@@ -28,10 +33,6 @@ export const testWithDb = <T>(
 ) => {
     test(name, async ({ expect }) => {
         await lock.runExclusive(async () => {
-            const tableNames = [];
-            for (const tableName in db._.tableNamesMap) {
-                if (tableName != '') tableNames.push(tableName);
-            }
             const query = `TRUNCATE TABLE ${tableNames
                 .map((tn) => tn.split('.'))
                 .map(([schema, tn]) => `"${schema}"."${tn}"`)

--- a/src/lib/testing/utils.ts
+++ b/src/lib/testing/utils.ts
@@ -22,7 +22,7 @@ for (const tableName in db._.tableNamesMap) {
 }
 
 export const mustGenerate = <T>(generated: T | null) => {
-    if (!generated) process.exit(1);
+    if (!generated) throw new Error('Data was not generated');
     return generated;
 };
 

--- a/src/lib/testing/utils.ts
+++ b/src/lib/testing/utils.ts
@@ -1,9 +1,7 @@
 import { createDb, type DB } from '$lib/server';
-import { publicChannelTable } from '$lib/server/db/public.channels.sql';
 import { tables } from '$lib/server/db/schema';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import { Mutex } from 'async-mutex';
-import { sql } from 'drizzle-orm';
 
 type DbStateGenerator<T> = (db: DB) => Promise<T>;
 type TestFunc<T> = (args: { db: DB; generated?: Awaited<T> }) => Promise<void>;

--- a/src/lib/testing/utils.ts
+++ b/src/lib/testing/utils.ts
@@ -1,17 +1,34 @@
 import { createDb, type DB } from '$lib/server';
+import { publicChannelTable } from '$lib/server/db/public.channels.sql';
+import { tables } from '$lib/server/db/schema';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { Mutex } from 'async-mutex';
+import { sql } from 'drizzle-orm';
 
-export const createTestingDb = async <T>(generator?: (db: DB) => Promise<T>) => {
-    const container = new PostgreSqlContainer();
-    const startedContainer = await container.start();
-    const db = await createDb(startedContainer.getConnectionUri());
+type DbStateGenerator<T> = (db: DB) => Promise<T>;
+type TestFunc<T> = (args: { db: DB; generated?: Awaited<T> }) => Promise<void>;
 
-    const generated = generator ? await generator(db) : null;
-
-    return { container: startedContainer, db, generated };
-};
+const container = new PostgreSqlContainer();
+const startedContainer = await container.start();
+const lock = new Mutex();
 
 export const mustGenerate = <T>(generated: T | null) => {
     if (!generated) process.exit(1);
     return generated;
+};
+
+export const withDb = async <T>(testFunc: TestFunc<T>, generator?: DbStateGenerator<T>) => {
+    await lock.runExclusive(async () => {
+        const db = await createDb(startedContainer.getConnectionUri());
+
+        await db.transaction(async (tx) => {
+            for (const table of tables) {
+                await tx.delete(table);
+            }
+        });
+
+        const generated = generator ? await generator(db) : undefined;
+
+        await testFunc({ db, generated });
+    });
 };

--- a/src/lib/testing/utils.ts
+++ b/src/lib/testing/utils.ts
@@ -2,12 +2,18 @@ import { createDb, type DB } from '$lib/server';
 import { tables } from '$lib/server/db/schema';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import { Mutex } from 'async-mutex';
+import { test, type ExpectStatic } from 'vitest';
 
 type DbStateGenerator<T> = (db: DB) => Promise<T>;
-type TestFunc<T> = (args: { db: DB; generated?: Awaited<T> }) => Promise<void>;
+type TestFunc<T> = (args: {
+    db: DB;
+    generated?: Awaited<T>;
+    expect: ExpectStatic;
+}) => Promise<void>;
 
 const container = new PostgreSqlContainer();
 const startedContainer = await container.start();
+const db = await createDb(startedContainer.getConnectionUri());
 const lock = new Mutex();
 
 export const mustGenerate = <T>(generated: T | null) => {
@@ -15,18 +21,22 @@ export const mustGenerate = <T>(generated: T | null) => {
     return generated;
 };
 
-export const withDb = async <T>(testFunc: TestFunc<T>, generator?: DbStateGenerator<T>) => {
-    await lock.runExclusive(async () => {
-        const db = await createDb(startedContainer.getConnectionUri());
+export const testWithDb = <T>(
+    name: string,
+    testFunc: TestFunc<T>,
+    generator?: DbStateGenerator<T>
+) => {
+    test(name, async ({ expect }) => {
+        await lock.runExclusive(async () => {
+            await db.transaction(async (tx) => {
+                for (const table of tables) {
+                    await tx.delete(table);
+                }
+            });
 
-        await db.transaction(async (tx) => {
-            for (const table of tables) {
-                await tx.delete(table);
-            }
+            const generated = generator ? await generator(db) : undefined;
+
+            await testFunc({ db, generated, expect });
         });
-
-        const generated = generator ? await generator(db) : undefined;
-
-        await testFunc({ db, generated });
     });
 };


### PR DESCRIPTION
I updated the test logic to create one container per test suite. I created `withDb` abstraction where database access is protected behind a mutex. You must obtain access before you can run your test using the database. It integrates existing logic for the generator functions and typesafety.